### PR TITLE
Add XGBoost & Random Forest experiments on SKAB datasets

### DIFF
--- a/Desktop/SKAB 2/README.md
+++ b/Desktop/SKAB 2/README.md
@@ -1,0 +1,122 @@
+# SKAB Anomaly Detection — Group 17 (Shreyan)
+
+**Dataset:** Skoltech Anomaly Benchmark (SKAB)  
+**Algorithms:** XGBoost, Random Forest  
+**Evaluation:** Group K-Fold Cross-Validation (grouped by file)  
+**Features:** 8 sensor signals + rolling mean & std (window=5) = 24 features  
+
+---
+
+## Datasets
+
+| Dataset | Files | Total Rows | Anomaly Rate |
+|---------|-------|------------|--------------|
+| valve1  | 16    | 18,162     | 34.7%        |
+| valve2  | 4     | 4,610      | ~35%         |
+| other   | 14    | ~20,000    | ~35%         |
+| anomaly-free (baseline) | 1 | 9,401 | 0% |
+
+> The anomaly-free baseline is used only to fit the StandardScaler — not for evaluation.
+
+---
+
+## Results Summary
+
+### Full Comparison
+
+| Dataset | Model         | F1     | Precision | Recall | ROC-AUC |
+|---------|---------------|--------|-----------|--------|---------|
+| valve1  | **XGBoost**   | **0.8454** | 0.9236 | 0.7794 | **0.8970** |
+| valve1  | Random Forest | 0.8371 | 0.9684    | 0.7372 | 0.8815  |
+| valve2  | **XGBoost**   | **0.8728** | 0.9286 | 0.8233 | **0.9262** |
+| valve2  | Random Forest | 0.8279 | 0.9657    | 0.7245 | 0.9175  |
+| other   | **XGBoost**   | **0.4240** | 0.5553 | 0.3429 | 0.5958  |
+| other   | Random Forest | 0.3437 | 0.5255    | 0.2554 | **0.6018** |
+
+### Overall Averages (Across All Datasets)
+
+| Model         | F1     | Precision | Recall | ROC-AUC |
+|---------------|--------|-----------|--------|---------|
+| **XGBoost**   | **0.7141** | 0.8025 | **0.6485** | **0.8063** |
+| Random Forest | 0.6696 | **0.8199** | 0.5724 | 0.8003  |
+
+> **XGBoost wins overall** on F1 and ROC-AUC. Random Forest has marginally higher precision.
+
+---
+
+## Per-File F1 — valve1
+
+| File   | XGBoost F1 | Random Forest F1 |
+|--------|------------|-----------------|
+| 0.csv  | 0.0718     | 0.0439          |
+| 1.csv  | 0.7252     | 0.0526          |
+| 2.csv  | 0.8649     | 0.8960          |
+| 3.csv  | 0.9294     | 0.9455          |
+| 4.csv  | 0.8832     | 0.9245          |
+| 5.csv  | 0.8649     | 0.8649          |
+| 6.csv  | 0.8270     | 0.8596          |
+| 7.csv  | 0.8492     | 0.8608          |
+| 8.csv  | 0.9937     | 0.9925          |
+| 9.csv  | 0.8743     | 0.8963          |
+| 10.csv | 0.8968     | 0.8984          |
+| 11.csv | 0.8075     | 0.8229          |
+| 12.csv | 0.9462     | 0.9730          |
+| 13.csv | 0.9088     | 0.8989          |
+| 14.csv | 0.8952     | 0.8986          |
+| 15.csv | 0.8345     | 0.8588          |
+
+---
+
+## Per-File F1 — valve2
+
+| File  | XGBoost F1 | Random Forest F1 |
+|-------|------------|-----------------|
+| 0.csv | 0.8833     | 0.6655          |
+| 1.csv | 0.9164     | 0.9120          |
+| 2.csv | 0.8768     | 0.8602          |
+| 3.csv | 0.8232     | 0.8559          |
+
+---
+
+## Per-File F1 — other
+
+| File   | XGBoost F1 | Random Forest F1 |
+|--------|------------|-----------------|
+| 9.csv  | 0.8055     | 0.8316          |
+| 11.csv | 0.8172     | 0.8187          |
+| 12.csv | 0.6949     | 0.4250          |
+| 13.csv | 0.8297     | 0.8090          |
+| 14.csv | 0.4770     | 0.0860          |
+| 15.csv | 0.3373     | 0.0766          |
+| 16.csv | 0.0480     | 0.0321          |
+| 17.csv | 0.0048     | 0.0050          |
+| 18.csv | 0.3636     | 0.1432          |
+| 19.csv | 0.3279     | 0.2119          |
+| 20.csv | 0.0000     | 0.0000          |
+| 21.csv | 0.0048     | 0.0000          |
+| 22.csv | 0.4217     | 0.4553          |
+| 23.csv | 0.0262     | 0.1772          |
+
+---
+
+## Key Findings
+
+- **XGBoost is the best overall model** — highest F1 and ROC-AUC on all three datasets.
+- **valve1 & valve2** — both models perform strongly. Most files score F1 > 0.82, with several above 0.93.
+- **other dataset** — both models struggle badly. XGBoost F1 = 0.424, Random Forest F1 = 0.344. Files 16, 17, 20, 21 score near zero, suggesting anomaly types in this group are fundamentally different and harder to generalise from valve training patterns.
+- **Random Forest** has higher precision (fewer false alarms) but consistently lower recall — it misses more real anomalies.
+- **XGBoost** has better recall — catches more anomalies but produces slightly more false positives.
+
+---
+
+## Files in This Branch
+
+| File | Description |
+|------|-------------|
+| `SKAB_Anomaly_Detection_shreyan_supervised_unsupervised.ipynb` | Initial notebook — valve1 only, 4 algorithms (XGBoost, RF, Isolation Forest, LSTM Autoencoder) |
+| `SKAB_XGBoost_RandomForest_AllDatasets.ipynb` | Extended notebook — all 3 datasets, XGBoost & Random Forest, runs locally |
+| `SKAB_Results_Report.pdf` | Full PDF report with charts, tables and findings |
+
+---
+
+*CITS5206 Capstone Group 17 — Shreyan Mittal — April 2026*

--- a/Desktop/SKAB 2/README.md
+++ b/Desktop/SKAB 2/README.md
@@ -99,7 +99,7 @@
 
 ---
 
-## Key Findings
+## Key Findings (Separate)
 
 - **XGBoost is the best overall model** — highest F1 and ROC-AUC on all three datasets.
 - **valve1 & valve2** — both models perform strongly. Most files score F1 > 0.82, with several above 0.93.
@@ -109,12 +109,84 @@
 
 ---
 
+## Combined Dataset Results (valve1 + valve2 + other)
+
+All 34 files merged into a single dataset (37,459 rows, 35.3% anomaly rate) and evaluated with Group 5-Fold CV grouped by dataset/file.
+
+### Summary
+
+| Model         | F1     | Precision | Recall | ROC-AUC |
+|---------------|--------|-----------|--------|---------|
+| **XGBoost**   | **0.6749** | 0.7868 | **0.5908** | 0.7893 |
+| Random Forest | 0.6655 | **0.8251** | 0.5577 | **0.8056** |
+
+### Fold-by-Fold F1
+
+| Fold | XGBoost | Random Forest |
+|------|---------|---------------|
+| 1    | 0.6565  | 0.6184        |
+| 2    | 0.5713  | 0.6049        |
+| 3    | 0.6877  | 0.7191        |
+| 4    | 0.7935  | 0.7709        |
+| 5    | 0.6634  | 0.6052        |
+
+### Combined vs Separate — Head to Head
+
+| Model         | Separate F1 | Combined F1 | Change | Separate ROC-AUC | Combined ROC-AUC | Change |
+|---------------|-------------|-------------|--------|------------------|------------------|--------|
+| XGBoost       | 0.7141      | 0.6749      | -0.039 | 0.8063           | 0.7893           | -0.017 |
+| Random Forest | 0.6696      | 0.6655      | -0.004 | 0.8003           | 0.8056           | +0.005 |
+
+> Training separately per dataset is stronger for XGBoost. Random Forest is almost unchanged, with a slight ROC-AUC gain when combined.
+
+### Per-File F1 — Combined Run
+
+| Dataset | File   | XGBoost F1 | RF F1  |
+|---------|--------|------------|--------|
+| other   | 9.csv  | 0.8010     | 0.8315 |
+| other   | 11.csv | 0.8385     | 0.8286 |
+| other   | 12.csv | 0.7318     | 0.4478 |
+| other   | 13.csv | 0.8443     | 0.7825 |
+| other   | 14.csv | 0.5183     | 0.1034 |
+| other   | 15.csv | 0.3627     | 0.0898 |
+| other   | 16.csv | 0.1331     | 0.2158 |
+| other   | 17.csv | 0.0000     | 0.0050 |
+| other   | 18.csv | 0.3011     | 0.1438 |
+| other   | 19.csv | 0.3706     | 0.3851 |
+| other   | 20.csv | 0.0086     | 0.0000 |
+| other   | 21.csv | 0.0000     | 0.0000 |
+| other   | 22.csv | 0.4822     | 0.4053 |
+| other   | 23.csv | 0.0391     | 0.0262 |
+| valve1  | 0.csv  | 0.0995     | 0.0439 |
+| valve1  | 1.csv  | 0.3217     | 0.0144 |
+| valve1  | 2.csv  | 0.8957     | 0.8916 |
+| valve1  | 3.csv  | 0.9371     | 0.9439 |
+| valve1  | 4.csv  | 0.7423     | 0.9474 |
+| valve1  | 5.csv  | 0.8627     | 0.8649 |
+| valve1  | 6.csv  | 0.8441     | 0.8596 |
+| valve1  | 7.csv  | 0.8575     | 0.8655 |
+| valve1  | 8.csv  | 0.9543     | 0.9913 |
+| valve1  | 9.csv  | 0.8766     | 0.8875 |
+| valve1  | 10.csv | 0.8971     | 0.9029 |
+| valve1  | 11.csv | 0.8436     | 0.8632 |
+| valve1  | 12.csv | 0.9718     | 0.9730 |
+| valve1  | 13.csv | 0.8626     | 0.8959 |
+| valve1  | 14.csv | 0.9181     | 0.9061 |
+| valve1  | 15.csv | 0.8668     | 0.8652 |
+| valve2  | 0.csv  | 0.7328     | 0.8209 |
+| valve2  | 1.csv  | 0.9032     | 0.9114 |
+| valve2  | 2.csv  | 0.9049     | 0.9120 |
+| valve2  | 3.csv  | 0.8434     | 0.8681 |
+
+---
+
 ## Files in This Branch
 
 | File | Description |
 |------|-------------|
 | `SKAB_Anomaly_Detection_shreyan_supervised_unsupervised.ipynb` | Initial notebook — valve1 only, 4 algorithms (XGBoost, RF, Isolation Forest, LSTM Autoencoder) |
-| `SKAB_XGBoost_RandomForest_AllDatasets.ipynb` | Extended notebook — all 3 datasets, XGBoost & Random Forest, runs locally |
+| `SKAB_XGBoost_RandomForest_AllDatasets.ipynb` | Separate-dataset notebook — valve1, valve2, other individually |
+| `SKAB_XGBoost_RandomForest_Combined.ipynb` | Combined-dataset notebook — all 34 files merged, XGBoost & RF |
 | `SKAB_Results_Report.pdf` | Full PDF report with charts, tables and findings |
 
 ---

--- a/Desktop/SKAB 2/SKAB_XGBoost_RandomForest_AllDatasets.ipynb
+++ b/Desktop/SKAB 2/SKAB_XGBoost_RandomForest_AllDatasets.ipynb
@@ -1,0 +1,415 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# SKAB Anomaly Detection — XGBoost & Random Forest on All Datasets\n",
+    "**Datasets:** valve1 (16 files), valve2 (4 files), other (14 files)  \n",
+    "**Algorithms:** XGBoost, Random Forest (supervised)  \n",
+    "**Evaluation:** F1, Precision, Recall, ROC-AUC — per dataset + per file  \n",
+    "**Note:** Runs locally. Data loaded from relative paths alongside this notebook."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Cell 1 — Install Dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -q xgboost scikit-learn pandas numpy matplotlib seaborn"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Cell 2 — Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import seaborn as sns\n",
+    "import warnings\n",
+    "warnings.filterwarnings('ignore')\n",
+    "\n",
+    "from xgboost import XGBClassifier\n",
+    "from sklearn.ensemble import RandomForestClassifier\n",
+    "from sklearn.preprocessing import StandardScaler\n",
+    "from sklearn.model_selection import GroupKFold\n",
+    "from sklearn.metrics import (\n",
+    "    f1_score, precision_score, recall_score,\n",
+    "    roc_auc_score, classification_report\n",
+    ")\n",
+    "\n",
+    "# Path to SKAB data (relative to this notebook)\n",
+    "BASE_DIR = os.path.dirname(os.path.abspath('__file__')) if '__file__' in dir() else os.getcwd()\n",
+    "print(f'Base directory: {BASE_DIR}')\n",
+    "\n",
+    "FEATURE_COLS = [\n",
+    "    'Accelerometer1RMS', 'Accelerometer2RMS', 'Current',\n",
+    "    'Pressure', 'Temperature', 'Thermocouple',\n",
+    "    'Voltage', 'Volume Flow RateRMS'\n",
+    "]\n",
+    "\n",
+    "DATASETS = {\n",
+    "    'valve1': [f'valve1/{i}.csv' for i in range(16)],\n",
+    "    'valve2': [f'valve2/{i}.csv' for i in range(4)],\n",
+    "    'other':  [f'other/{f}' for f in sorted(os.listdir(os.path.join(BASE_DIR, 'other'))) if f.endswith('.csv')]\n",
+    "}\n",
+    "\n",
+    "print('\\nDataset file counts:')\n",
+    "for name, files in DATASETS.items():\n",
+    "    print(f'  {name}: {len(files)} files')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Cell 3 — Load All Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def load_csv(path):\n",
+    "    df = pd.read_csv(path, sep=';', parse_dates=['datetime'])\n",
+    "    return df.sort_values('datetime').reset_index(drop=True)\n",
+    "\n",
+    "# Anomaly-free baseline (for scaler fitting)\n",
+    "baseline_df = load_csv(os.path.join(BASE_DIR, 'anomaly-free', 'anomaly-free.csv'))\n",
+    "print(f'Baseline shape: {baseline_df.shape}')\n",
+    "\n",
+    "# Load all datasets\n",
+    "all_data = {}\n",
+    "for dataset_name, file_list in DATASETS.items():\n",
+    "    dfs = []\n",
+    "    for fpath in file_list:\n",
+    "        full_path = os.path.join(BASE_DIR, fpath)\n",
+    "        if os.path.exists(full_path):\n",
+    "            df = load_csv(full_path)\n",
+    "            df['source_file'] = os.path.basename(fpath)\n",
+    "            dfs.append(df)\n",
+    "        else:\n",
+    "            print(f'  WARNING: {full_path} not found, skipping.')\n",
+    "    combined = pd.concat(dfs, ignore_index=True)\n",
+    "    all_data[dataset_name] = combined\n",
+    "    print(f'{dataset_name}: {len(dfs)} files, {len(combined)} rows, '\n",
+    "          f'anomaly rate: {combined[\"anomaly\"].mean():.1%}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Cell 4 — Feature Engineering"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def add_rolling_features(df, window=5):\n",
+    "    df = df.copy()\n",
+    "    for col in FEATURE_COLS:\n",
+    "        df[f'{col}_roll_mean'] = df[col].rolling(window, min_periods=1).mean()\n",
+    "        df[f'{col}_roll_std']  = df[col].rolling(window, min_periods=1).std().fillna(0)\n",
+    "    return df\n",
+    "\n",
+    "EXTENDED_COLS = FEATURE_COLS + \\\n",
+    "    [f'{c}_roll_mean' for c in FEATURE_COLS] + \\\n",
+    "    [f'{c}_roll_std'  for c in FEATURE_COLS]\n",
+    "\n",
+    "# Fit scaler on anomaly-free baseline only\n",
+    "baseline_feat = add_rolling_features(baseline_df)\n",
+    "scaler = StandardScaler()\n",
+    "scaler.fit(baseline_feat[EXTENDED_COLS])\n",
+    "\n",
+    "# Apply to all datasets\n",
+    "dataset_features = {}\n",
+    "for name, df in all_data.items():\n",
+    "    feat_df = add_rolling_features(df)\n",
+    "    X = scaler.transform(feat_df[EXTENDED_COLS])\n",
+    "    y = feat_df['anomaly'].values\n",
+    "    groups = feat_df['source_file'].values\n",
+    "    dataset_features[name] = (X, y, groups, feat_df)\n",
+    "    print(f'{name}: X={X.shape}, y={y.shape}, anomaly rate={y.mean():.1%}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Cell 5 — Train & Evaluate XGBoost and Random Forest (Per Dataset)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def evaluate_models(X, y, groups, dataset_name, n_splits=5):\n",
+    "    neg = (y == 0).sum()\n",
+    "    pos = (y == 1).sum()\n",
+    "    scale_pos = neg / pos if pos > 0 else 1.0\n",
+    "\n",
+    "    # Adjust splits if fewer unique groups than n_splits\n",
+    "    n_unique_groups = len(np.unique(groups))\n",
+    "    actual_splits = min(n_splits, n_unique_groups)\n",
+    "\n",
+    "    models = {\n",
+    "        'XGBoost': XGBClassifier(\n",
+    "            n_estimators=300, max_depth=6,\n",
+    "            scale_pos_weight=scale_pos,\n",
+    "            eval_metric='logloss',\n",
+    "            random_state=42, n_jobs=-1\n",
+    "        ),\n",
+    "        'Random Forest': RandomForestClassifier(\n",
+    "            n_estimators=300,\n",
+    "            class_weight='balanced',\n",
+    "            random_state=42, n_jobs=-1\n",
+    "        )\n",
+    "    }\n",
+    "\n",
+    "    gkf = GroupKFold(n_splits=actual_splits)\n",
+    "    results = {}\n",
+    "\n",
+    "    print(f'\\n{\"=\"*60}')\n",
+    "    print(f'Dataset: {dataset_name}  |  Rows: {len(y)}  |  Folds: {actual_splits}')\n",
+    "    print(f'{\"=\"*60}')\n",
+    "\n",
+    "    for model_name, clf in models.items():\n",
+    "        print(f'\\n--- {model_name} ---')\n",
+    "        all_preds  = np.zeros(len(y))\n",
+    "        all_probas = np.zeros(len(y))\n",
+    "\n",
+    "        for fold, (train_idx, test_idx) in enumerate(gkf.split(X, y, groups)):\n",
+    "            clf.fit(X[train_idx], y[train_idx])\n",
+    "            all_preds[test_idx]  = clf.predict(X[test_idx])\n",
+    "            all_probas[test_idx] = clf.predict_proba(X[test_idx])[:, 1]\n",
+    "            fold_f1 = f1_score(y[test_idx], all_preds[test_idx], zero_division=0)\n",
+    "            print(f'  Fold {fold+1}  F1: {fold_f1:.4f}')\n",
+    "\n",
+    "        print(classification_report(y, all_preds, target_names=['Normal', 'Anomaly'], zero_division=0))\n",
+    "        print(f'ROC-AUC: {roc_auc_score(y, all_probas):.4f}')\n",
+    "\n",
+    "        results[model_name] = {\n",
+    "            'preds': all_preds,\n",
+    "            'probas': all_probas,\n",
+    "            'f1':        round(f1_score(y, all_preds, zero_division=0), 4),\n",
+    "            'precision': round(precision_score(y, all_preds, zero_division=0), 4),\n",
+    "            'recall':    round(recall_score(y, all_preds, zero_division=0), 4),\n",
+    "            'roc_auc':   round(roc_auc_score(y, all_probas), 4)\n",
+    "        }\n",
+    "\n",
+    "    return results\n",
+    "\n",
+    "\n",
+    "all_results = {}\n",
+    "for dataset_name, (X, y, groups, feat_df) in dataset_features.items():\n",
+    "    all_results[dataset_name] = evaluate_models(X, y, groups, dataset_name)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Cell 6 — Summary Table: All Datasets × Both Models"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rows = []\n",
+    "for dataset_name, model_results in all_results.items():\n",
+    "    for model_name, metrics in model_results.items():\n",
+    "        rows.append({\n",
+    "            'Dataset':   dataset_name,\n",
+    "            'Model':     model_name,\n",
+    "            'F1':        metrics['f1'],\n",
+    "            'Precision': metrics['precision'],\n",
+    "            'Recall':    metrics['recall'],\n",
+    "            'ROC-AUC':   metrics['roc_auc']\n",
+    "        })\n",
+    "\n",
+    "summary_df = pd.DataFrame(rows)\n",
+    "print('\\n========== FULL SUMMARY ==========\\n')\n",
+    "print(summary_df.to_string(index=False))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Cell 7 — Heatmap: F1 Score by Dataset and Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pivot_f1 = summary_df.pivot(index='Dataset', columns='Model', values='F1')\n",
+    "\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(14, 4))\n",
+    "\n",
+    "# F1 heatmap\n",
+    "sns.heatmap(pivot_f1, annot=True, fmt='.4f', cmap='YlGn',\n",
+    "            vmin=0, vmax=1, ax=axes[0], linewidths=0.5)\n",
+    "axes[0].set_title('F1 Score by Dataset & Model', fontweight='bold')\n",
+    "\n",
+    "# ROC-AUC heatmap\n",
+    "pivot_auc = summary_df.pivot(index='Dataset', columns='Model', values='ROC-AUC')\n",
+    "sns.heatmap(pivot_auc, annot=True, fmt='.4f', cmap='Blues',\n",
+    "            vmin=0, vmax=1, ax=axes[1], linewidths=0.5)\n",
+    "axes[1].set_title('ROC-AUC by Dataset & Model', fontweight='bold')\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.savefig('heatmap_all_datasets.png', dpi=150, bbox_inches='tight')\n",
+    "plt.show()\n",
+    "print('Saved: heatmap_all_datasets.png')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Cell 8 — Per-File F1 Breakdown (All Datasets)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def per_file_f1(dataset_name, model_name, feat_df, y, preds):\n",
+    "    rows = []\n",
+    "    for fname in sorted(feat_df['source_file'].unique()):\n",
+    "        mask = feat_df['source_file'].values == fname\n",
+    "        f1  = f1_score(y[mask], preds[mask], zero_division=0)\n",
+    "        anom = y[mask].mean()\n",
+    "        rows.append({'Dataset': dataset_name, 'Model': model_name,\n",
+    "                     'File': fname, 'F1': round(f1, 4), 'Anomaly Rate': round(anom, 3)})\n",
+    "    return rows\n",
+    "\n",
+    "per_file_rows = []\n",
+    "for dataset_name, (X, y, groups, feat_df) in dataset_features.items():\n",
+    "    for model_name, metrics in all_results[dataset_name].items():\n",
+    "        per_file_rows.extend(\n",
+    "            per_file_f1(dataset_name, model_name, feat_df, y, metrics['preds'])\n",
+    "        )\n",
+    "\n",
+    "per_file_df = pd.DataFrame(per_file_rows)\n",
+    "print('\\n========== PER-FILE F1 BREAKDOWN ==========\\n')\n",
+    "print(per_file_df.to_string(index=False))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Cell 9 — Bar Charts: Per-File F1 for Each Dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset_names = list(DATASETS.keys())\n",
+    "fig, axes = plt.subplots(len(dataset_names), 1,\n",
+    "                         figsize=(14, 5 * len(dataset_names)),\n",
+    "                         constrained_layout=True)\n",
+    "\n",
+    "colors = {'XGBoost': 'steelblue', 'Random Forest': 'darkorange'}\n",
+    "\n",
+    "for ax, dataset_name in zip(axes, dataset_names):\n",
+    "    subset = per_file_df[per_file_df['Dataset'] == dataset_name]\n",
+    "    files  = sorted(subset['File'].unique())\n",
+    "    x = np.arange(len(files))\n",
+    "    width = 0.35\n",
+    "\n",
+    "    for i, model_name in enumerate(['XGBoost', 'Random Forest']):\n",
+    "        model_data = subset[subset['Model'] == model_name].set_index('File')\n",
+    "        f1_vals = [model_data.loc[f, 'F1'] if f in model_data.index else 0 for f in files]\n",
+    "        ax.bar(x + i * width, f1_vals, width, label=model_name,\n",
+    "               color=colors[model_name], alpha=0.85)\n",
+    "\n",
+    "    ax.set_xticks(x + width / 2)\n",
+    "    ax.set_xticklabels(files, rotation=45, ha='right')\n",
+    "    ax.set_ylim(0, 1.1)\n",
+    "    ax.set_ylabel('F1 Score')\n",
+    "    ax.set_title(f'Per-File F1 Score — {dataset_name}', fontweight='bold')\n",
+    "    ax.legend()\n",
+    "    ax.axhline(0.8, color='red', linestyle='--', lw=1, alpha=0.5, label='0.8 threshold')\n",
+    "\n",
+    "plt.savefig('per_file_f1_all_datasets.png', dpi=150, bbox_inches='tight')\n",
+    "plt.show()\n",
+    "print('Saved: per_file_f1_all_datasets.png')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Cell 10 — Best Model Per Dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('\\n========== BEST MODEL PER DATASET (by F1) ==========\\n')\n",
+    "best = summary_df.loc[summary_df.groupby('Dataset')['F1'].idxmax()]\n",
+    "print(best.to_string(index=False))\n",
+    "\n",
+    "print('\\n========== OVERALL AVERAGE (across all datasets) ==========\\n')\n",
+    "overall = summary_df.groupby('Model')[['F1', 'Precision', 'Recall', 'ROC-AUC']].mean().round(4)\n",
+    "print(overall)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/Desktop/SKAB 2/SKAB_XGBoost_RandomForest_Combined.ipynb
+++ b/Desktop/SKAB 2/SKAB_XGBoost_RandomForest_Combined.ipynb
@@ -1,0 +1,363 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# SKAB Anomaly Detection — XGBoost & Random Forest on Combined Dataset\n",
+    "**Datasets:** valve1 + valve2 + other merged into one (37,459 rows, 34 files)  \n",
+    "**Algorithms:** XGBoost, Random Forest (supervised)  \n",
+    "**Evaluation:** Group 5-Fold CV grouped by dataset/file  \n",
+    "**Note:** Runs locally. Data loaded from relative paths alongside this notebook."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Cell 1 — Install Dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -q xgboost scikit-learn pandas numpy matplotlib seaborn"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Cell 2 — Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import seaborn as sns\n",
+    "import warnings\n",
+    "warnings.filterwarnings('ignore')\n",
+    "\n",
+    "from xgboost import XGBClassifier\n",
+    "from sklearn.ensemble import RandomForestClassifier\n",
+    "from sklearn.preprocessing import StandardScaler\n",
+    "from sklearn.model_selection import GroupKFold\n",
+    "from sklearn.metrics import (\n",
+    "    f1_score, precision_score, recall_score,\n",
+    "    roc_auc_score, classification_report\n",
+    ")\n",
+    "\n",
+    "BASE_DIR = os.getcwd()\n",
+    "print(f'Base directory: {BASE_DIR}')\n",
+    "\n",
+    "FEATURE_COLS = [\n",
+    "    'Accelerometer1RMS', 'Accelerometer2RMS', 'Current',\n",
+    "    'Pressure', 'Temperature', 'Thermocouple',\n",
+    "    'Voltage', 'Volume Flow RateRMS'\n",
+    "]\n",
+    "\n",
+    "DATASETS = {\n",
+    "    'valve1': [f'valve1/{i}.csv' for i in range(16)],\n",
+    "    'valve2': [f'valve2/{i}.csv' for i in range(4)],\n",
+    "    'other':  [f'other/{f}' for f in sorted(os.listdir(os.path.join(BASE_DIR, 'other'))) if f.endswith('.csv')]\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Cell 3 — Load & Combine All Datasets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def load_csv(path):\n",
+    "    df = pd.read_csv(path, sep=';', parse_dates=['datetime'])\n",
+    "    return df.sort_values('datetime').reset_index(drop=True)\n",
+    "\n",
+    "# Anomaly-free baseline for scaler\n",
+    "baseline_df = load_csv(os.path.join(BASE_DIR, 'anomaly-free', 'anomaly-free.csv'))\n",
+    "print(f'Baseline shape: {baseline_df.shape}')\n",
+    "\n",
+    "# Load & merge all datasets\n",
+    "all_dfs = []\n",
+    "for dataset_name, file_list in DATASETS.items():\n",
+    "    for fpath in file_list:\n",
+    "        full_path = os.path.join(BASE_DIR, fpath)\n",
+    "        if os.path.exists(full_path):\n",
+    "            df = load_csv(full_path)\n",
+    "            df['source_file']    = os.path.basename(fpath)\n",
+    "            df['source_dataset'] = dataset_name\n",
+    "            all_dfs.append(df)\n",
+    "\n",
+    "combined = pd.concat(all_dfs, ignore_index=True)\n",
+    "print(f'\\nCombined dataset: {len(combined)} rows, {combined[\"source_file\"].nunique()} files')\n",
+    "print(f'Overall anomaly rate: {combined[\"anomaly\"].mean():.1%}')\n",
+    "print('\\nBreakdown by dataset:')\n",
+    "print(combined.groupby('source_dataset')['anomaly'].agg(['count','mean']).rename(columns={'count':'rows','mean':'anomaly_rate'}))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Cell 4 — Feature Engineering"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def add_rolling_features(df, window=5):\n",
+    "    df = df.copy()\n",
+    "    for col in FEATURE_COLS:\n",
+    "        df[f'{col}_roll_mean'] = df[col].rolling(window, min_periods=1).mean()\n",
+    "        df[f'{col}_roll_std']  = df[col].rolling(window, min_periods=1).std().fillna(0)\n",
+    "    return df\n",
+    "\n",
+    "EXTENDED_COLS = FEATURE_COLS + \\\n",
+    "    [f'{c}_roll_mean' for c in FEATURE_COLS] + \\\n",
+    "    [f'{c}_roll_std'  for c in FEATURE_COLS]\n",
+    "\n",
+    "# Fit scaler on anomaly-free baseline only\n",
+    "baseline_feat = add_rolling_features(baseline_df)\n",
+    "scaler = StandardScaler()\n",
+    "scaler.fit(baseline_feat[EXTENDED_COLS])\n",
+    "\n",
+    "# Apply to combined\n",
+    "feat_df = add_rolling_features(combined)\n",
+    "X       = scaler.transform(feat_df[EXTENDED_COLS])\n",
+    "y       = feat_df['anomaly'].values\n",
+    "groups  = (feat_df['source_dataset'] + '/' + feat_df['source_file']).values\n",
+    "\n",
+    "print(f'Feature matrix: {X.shape}')\n",
+    "print(f'Unique groups (files): {len(np.unique(groups))}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Cell 5 — Train & Evaluate Both Models"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "neg, pos  = (y == 0).sum(), (y == 1).sum()\n",
+    "scale_pos = neg / pos\n",
+    "\n",
+    "models = {\n",
+    "    'XGBoost': XGBClassifier(\n",
+    "        n_estimators=300, max_depth=6,\n",
+    "        scale_pos_weight=scale_pos,\n",
+    "        eval_metric='logloss',\n",
+    "        random_state=42, n_jobs=-1\n",
+    "    ),\n",
+    "    'Random Forest': RandomForestClassifier(\n",
+    "        n_estimators=300,\n",
+    "        class_weight='balanced',\n",
+    "        random_state=42, n_jobs=-1\n",
+    "    )\n",
+    "}\n",
+    "\n",
+    "gkf = GroupKFold(n_splits=5)\n",
+    "all_results   = {}\n",
+    "per_file_rows = []\n",
+    "\n",
+    "for model_name, clf in models.items():\n",
+    "    print(f'\\n=== {model_name} — Combined Dataset (Group 5-Fold CV) ===')\n",
+    "    all_preds  = np.zeros(len(y))\n",
+    "    all_probas = np.zeros(len(y))\n",
+    "\n",
+    "    for fold, (train_idx, test_idx) in enumerate(gkf.split(X, y, groups)):\n",
+    "        clf.fit(X[train_idx], y[train_idx])\n",
+    "        all_preds[test_idx]  = clf.predict(X[test_idx])\n",
+    "        all_probas[test_idx] = clf.predict_proba(X[test_idx])[:, 1]\n",
+    "        fold_f1 = f1_score(y[test_idx], all_preds[test_idx], zero_division=0)\n",
+    "        print(f'  Fold {fold+1}  F1: {fold_f1:.4f}')\n",
+    "\n",
+    "    print(classification_report(y, all_preds, target_names=['Normal','Anomaly'], zero_division=0))\n",
+    "    print(f'ROC-AUC: {roc_auc_score(y, all_probas):.4f}')\n",
+    "\n",
+    "    all_results[model_name] = {\n",
+    "        'preds': all_preds, 'probas': all_probas,\n",
+    "        'f1':        round(f1_score(y, all_preds, zero_division=0), 4),\n",
+    "        'precision': round(precision_score(y, all_preds, zero_division=0), 4),\n",
+    "        'recall':    round(recall_score(y, all_preds, zero_division=0), 4),\n",
+    "        'roc_auc':   round(roc_auc_score(y, all_probas), 4)\n",
+    "    }\n",
+    "\n",
+    "    for grp in sorted(np.unique(groups)):\n",
+    "        mask = groups == grp\n",
+    "        f1   = f1_score(y[mask], all_preds[mask], zero_division=0)\n",
+    "        ds, fname = grp.split('/')\n",
+    "        per_file_rows.append({\n",
+    "            'Dataset': ds, 'File': fname, 'Model': model_name,\n",
+    "            'F1': round(f1, 4), 'Anomaly Rate': round(y[mask].mean(), 3)\n",
+    "        })\n",
+    "\n",
+    "per_file_df = pd.DataFrame(per_file_rows)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Cell 6 — Summary Table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "summary_rows = []\n",
+    "for model_name, m in all_results.items():\n",
+    "    summary_rows.append({\n",
+    "        'Model': model_name, 'F1': m['f1'],\n",
+    "        'Precision': m['precision'], 'Recall': m['recall'], 'ROC-AUC': m['roc_auc']\n",
+    "    })\n",
+    "\n",
+    "summary_df = pd.DataFrame(summary_rows)\n",
+    "print('\\n========== COMBINED DATASET — FINAL SUMMARY ==========')\n",
+    "print(summary_df.to_string(index=False))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Cell 7 — Per-File F1 Breakdown"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for model_name in ['XGBoost', 'Random Forest']:\n",
+    "    print(f'\\n========== PER-FILE F1 — {model_name} ==========')\n",
+    "    sub = per_file_df[per_file_df['Model'] == model_name][['Dataset','File','F1','Anomaly Rate']]\n",
+    "    print(sub.to_string(index=False))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Cell 8 — Bar Charts: Per-File F1 by Dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset_names  = ['valve1', 'valve2', 'other']\n",
+    "colors_map     = {'XGBoost': '#2196F3', 'Random Forest': '#FF9800'}\n",
+    "\n",
+    "fig, axes = plt.subplots(len(dataset_names), 1,\n",
+    "                         figsize=(14, 5 * len(dataset_names)),\n",
+    "                         constrained_layout=True)\n",
+    "\n",
+    "for ax, dataset_name in zip(axes, dataset_names):\n",
+    "    subset = per_file_df[per_file_df['Dataset'] == dataset_name]\n",
+    "    files  = sorted(subset['File'].unique())\n",
+    "    x      = np.arange(len(files))\n",
+    "    width  = 0.35\n",
+    "\n",
+    "    for i, model_name in enumerate(['XGBoost', 'Random Forest']):\n",
+    "        model_data = subset[subset['Model'] == model_name].set_index('File')\n",
+    "        f1_vals    = [model_data.loc[f, 'F1'] if f in model_data.index else 0 for f in files]\n",
+    "        ax.bar(x + i * width, f1_vals, width, label=model_name,\n",
+    "               color=colors_map[model_name], alpha=0.85)\n",
+    "\n",
+    "    ax.set_xticks(x + width / 2)\n",
+    "    ax.set_xticklabels(files, rotation=45, ha='right', fontsize=9)\n",
+    "    ax.set_ylim(0, 1.15)\n",
+    "    ax.set_ylabel('F1 Score')\n",
+    "    ax.set_title(f'Per-File F1 — {dataset_name} (Combined Training)', fontweight='bold')\n",
+    "    ax.axhline(0.8, color='red', linestyle='--', lw=1, alpha=0.5, label='0.8 threshold')\n",
+    "    ax.legend()\n",
+    "\n",
+    "plt.savefig('per_file_f1_combined.png', dpi=150, bbox_inches='tight')\n",
+    "plt.show()\n",
+    "print('Saved: per_file_f1_combined.png')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Cell 9 — Combined vs Separate Comparison"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Separate-run results (from SKAB_XGBoost_RandomForest_AllDatasets.ipynb)\n",
+    "separate = {\n",
+    "    'XGBoost':       {'F1': 0.7141, 'Precision': 0.8025, 'Recall': 0.6485, 'ROC-AUC': 0.8063},\n",
+    "    'Random Forest': {'F1': 0.6696, 'Precision': 0.8199, 'Recall': 0.5724, 'ROC-AUC': 0.8003},\n",
+    "}\n",
+    "\n",
+    "compare_rows = []\n",
+    "for model_name, m in all_results.items():\n",
+    "    sep = separate[model_name]\n",
+    "    compare_rows.append({\n",
+    "        'Model':            model_name,\n",
+    "        'Combined F1':      m['f1'],\n",
+    "        'Separate F1':      sep['F1'],\n",
+    "        'F1 Change':        round(m['f1'] - sep['F1'], 4),\n",
+    "        'Combined ROC-AUC': m['roc_auc'],\n",
+    "        'Separate ROC-AUC': sep['ROC-AUC'],\n",
+    "        'ROC-AUC Change':   round(m['roc_auc'] - sep['ROC-AUC'], 4),\n",
+    "    })\n",
+    "\n",
+    "compare_df = pd.DataFrame(compare_rows)\n",
+    "print('\\n========== COMBINED vs SEPARATE ==========\\n')\n",
+    "print(compare_df.to_string(index=False))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- Runs XGBoost and Random Forest with Group K-Fold CV across all 34 SKAB files (valve1, valve2, other)
- Includes per-dataset and per-file F1 breakdown with heatmap visualisations
- Additional notebook merges all 34 files into one combined dataset (37,459 rows) and compares combined vs separate training results
- README added with full metrics table and key findings